### PR TITLE
爆炸收集

### DIFF
--- a/src/main/java/cc/ranmc/hopper/listener/MainListener.java
+++ b/src/main/java/cc/ranmc/hopper/listener/MainListener.java
@@ -28,7 +28,18 @@ import static cc.ranmc.hopper.utils.HopperUtil.hopper;
 public class MainListener implements Listener {
 
     private static final Main plugin = Main.getInstance();
-
+    
+    @EventHandler
+    public void onEntityExplodeEvent(EntityExplodeEvent event) {
+        if (!plugin.isEnable() &&
+                event.isCancelled() &&
+                !plugin.getConfig().getBoolean("explode", true) &&
+                event.getEntityType() != EntityType.TNT) {
+            return;
+        }
+        hopper(event.getLocation());
+    }
+    
     @EventHandler
     private void onBlockGrowEvent(BlockGrowEvent event) {
         if (!plugin.isEnable() &&

--- a/src/main/java/cc/ranmc/hopper/listener/MainListener.java
+++ b/src/main/java/cc/ranmc/hopper/listener/MainListener.java
@@ -75,7 +75,7 @@ public class MainListener implements Listener {
         if (!plugin.isEnable() && event.isCancelled()) return;
         Block block = event.getBlock();
         Player player = event.getPlayer();
-        if (!event.isCancelled() && block.getType() == Material.HOPPER) {
+        if (block.getType() == Material.HOPPER) {
             String chunkKey = getKey(block.getChunk());
             if (plugin.getHopperCountMap().containsKey(chunkKey)) {
                 int count = plugin.getHopperCountMap().get(chunkKey);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,12 +2,14 @@
 enable: true
 # 活塞推出物品后收集
 piston: true
-# 生物丢弃或掉落物品后收集
+# 生物死亡掉落物品后收集
 entity: true
 # 方块被破坏后收集
 block: true
 # 作物生长后收集
 grow: true
+# TNT爆炸破坏方块收集
+explode: true
 
 # 插件前缀
 prefix: "&b[区块漏斗]"


### PR DESCRIPTION
有个问题：村民农场可以用entityChangeBlockEvent检测生物类型实现，但是如果收集萝卜和土豆这类似乎会造成村民没种子的情况吧，可能加个更长的延迟应该会好一点